### PR TITLE
fix(upsert-edge-list): await the transaction.commit

### DIFF
--- a/src/upsert-edge-list/upsert-edge-list.ts
+++ b/src/upsert-edge-list/upsert-edge-list.ts
@@ -46,7 +46,7 @@ export async function xUpsertEdgeListCommitTxn(upsertFn: (input?: any) => IUpser
 
   try {
     result = await xUpsertEdgeList(upsertFn, upsertNode, nodes, transaction, _dgraph);
-    transaction.commit();
+    await transaction.commit();
   }
   catch(e) {
     error = e;


### PR DESCRIPTION
transaction.commit was not being awaited causing random timing failures in the specs